### PR TITLE
Fix to memory_executor

### DIFF
--- a/lib/rgviz/memory_executor.rb
+++ b/lib/rgviz/memory_executor.rb
@@ -12,7 +12,7 @@ module Rgviz
       @labels = {}
     end
 
-    def execute(query)
+    def execute(query, options = {})
       @query = query
       @query = Parser.parse(@query) unless @query.kind_of?(Query)
       @table = Table.new


### PR DESCRIPTION
Rgviz-rails expects this method to take two parameters.
